### PR TITLE
Remove stray backtick fences from Python files

### DIFF
--- a/python-ai-services/api/v1/alert_routes.py
+++ b/python-ai-services/api/v1/alert_routes.py
@@ -112,4 +112,3 @@ async def delete_specific_alert_config(
     if not deleted: # Should ideally not happen if previous check passed
         raise HTTPException(status_code=404, detail=f"Alert config {alert_id} could not be deleted or was already deleted.")
     return None # For 204 response
-```

--- a/python-ai-services/api/v1/dashboard_data_routes.py
+++ b/python-ai-services/api/v1/dashboard_data_routes.py
@@ -192,4 +192,3 @@ async def get_agent_equity_curve(
 # The following @router.get an exact duplicate of the one defined earlier in the file.
 # This was likely a copy-paste error during previous modifications. Removing it.
 # @router.get("/agents/{agent_id}/portfolio/summary", response_model=PortfolioSummary)
-```

--- a/python-ai-services/api/v1/monitoring_routes.py
+++ b/python-ai-services/api/v1/monitoring_routes.py
@@ -240,4 +240,3 @@ async def get_system_health_summary(request: Request):
         # timestamp will use default_factory
     )
 
-```

--- a/python-ai-services/api/v1/performance_routes.py
+++ b/python-ai-services/api/v1/performance_routes.py
@@ -46,4 +46,3 @@ async def get_agent_performance_metrics(
         # Catch any unexpected errors from the service layer
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred while calculating performance metrics: {str(e)}")
 
-```

--- a/python-ai-services/api/v1/simulation_routes.py
+++ b/python-ai-services/api/v1/simulation_routes.py
@@ -84,4 +84,3 @@ async def run_backtest_endpoint(
 # To integrate this router into your main FastAPI application:
 # from .simulation_routes import router as simulation_router
 # app.include_router(simulation_router, prefix="/api/v1")
-```

--- a/python-ai-services/api/v1/websocket_routes.py
+++ b/python-ai-services/api/v1/websocket_routes.py
@@ -49,4 +49,3 @@ async def websocket_dashboard_endpoint(websocket: WebSocket, client_id: str):
 # To include this router in your main FastAPI application (e.g., in main.py):
 # from python_ai_services.api.v1 import websocket_routes
 # app.include_router(websocket_routes.router) # No prefix for /ws routes typically, or specific like /ws_api/v1
-```

--- a/python-ai-services/auth/dependencies.py
+++ b/python-ai-services/auth/dependencies.py
@@ -99,4 +99,3 @@ async def get_current_active_user(
         logger.error(f"Unexpected error during token validation: {e}", exc_info=True)
         raise credentials_exception from e
 
-```

--- a/python-ai-services/core/database.py
+++ b/python-ai-services/core/database.py
@@ -39,4 +39,3 @@ def get_db():
     finally:
         db.close()
 
-```

--- a/python-ai-services/core/factories.py
+++ b/python-ai-services/core/factories.py
@@ -118,4 +118,3 @@ def get_dex_execution_service_instance(
     except Exception as e: # Catch any other unexpected errors
         logger.error(f"DEX Factory: Agent {agent_config.agent_id}: Unexpected error creating DEXExecutionService: {e}", exc_info=True)
         return None
-```

--- a/python-ai-services/core/scheduler_setup.py
+++ b/python-ai-services/core/scheduler_setup.py
@@ -135,4 +135,3 @@ def shutdown_scheduler(wait: bool = True):
 
 # if __name__ == "__main__":
 #    asyncio.run(main_test())
-```

--- a/python-ai-services/core/websocket_manager.py
+++ b/python-ai-services/core/websocket_manager.py
@@ -104,4 +104,3 @@ class ConnectionManager:
 
 # Singleton instance
 connection_manager = ConnectionManager()
-```

--- a/python-ai-services/models/agent_models.py
+++ b/python-ai-services/models/agent_models.py
@@ -153,4 +153,3 @@ class AgentUpdateRequest(BaseModel):
     parent_agent_id: Optional[str] = None
     operational_parameters: Optional[Dict[str, Any]] = None
     is_active: Optional[bool] = None
-```

--- a/python-ai-services/models/compliance_models.py
+++ b/python-ai-services/models/compliance_models.py
@@ -32,4 +32,3 @@ class ViolatedRuleInfo(BaseModel):
 class ComplianceCheckResult(BaseModel):
     is_compliant: bool = True
     violated_rules: List[ViolatedRuleInfo] = Field(default_factory=list)
-```

--- a/python-ai-services/models/crew_models.py
+++ b/python-ai-services/models/crew_models.py
@@ -139,4 +139,3 @@ class AgentTask(BaseModel):
         use_enum_values = True # Ensures enum values (strings) are used in serialization
         # For FastAPI, orm_mode or from_attributes = True might be needed if creating from ORM objects
         # For now, this is a data transfer object.
-```

--- a/python-ai-services/models/db_models.py
+++ b/python-ai-services/models/db_models.py
@@ -90,4 +90,3 @@ class PortfolioSnapshotDB(Base):
     agent_id = Column(String, ForeignKey("agent_configs.agent_id", ondelete="CASCADE"), nullable=False, index=True)
     timestamp = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
     total_equity_usd = Column(Float, nullable=False)
-```

--- a/python-ai-services/models/event_bus_models.py
+++ b/python-ai-services/models/event_bus_models.py
@@ -65,4 +65,3 @@ class NewsArticleEventPayload(BaseModel):
     sentiment_label: Literal["positive", "negative", "neutral"] = "neutral"
     matched_keywords: List[str] = Field(default_factory=list)
     raw_content_snippet: Optional[str] = None # Optional: a snippet of original text
-```

--- a/python-ai-services/models/learning_models.py
+++ b/python-ai-services/models/learning_models.py
@@ -31,4 +31,3 @@ class LearningLogEntry(BaseModel):
         #     uuid.UUID: lambda v: str(v),
         # }
         pass
-```

--- a/python-ai-services/models/simulation_models.py
+++ b/python-ai-services/models/simulation_models.py
@@ -54,4 +54,3 @@ class BacktestResult(BaseModel):
     list_of_simulated_trades: List[SimulatedTrade] = Field(default_factory=list)
     equity_curve: List[EquityDataPoint] = Field(default_factory=list)
     # Optional: Sharpe Ratio, Sortino, etc. - defer for now
-```

--- a/python-ai-services/models/strategy_models.py
+++ b/python-ai-services/models/strategy_models.py
@@ -324,7 +324,6 @@ class ElliottWaveConfig(BaseModel):
         ElliottWaveConfig(**invalid_ew_data_extra)
     except ValidationError as e:
         logger.error(f"Error creating invalid EW config (extra field) (as expected): {e}")
-```
 
 import uuid
 from datetime import datetime

--- a/python-ai-services/models/trade_history_models.py
+++ b/python-ai-services/models/trade_history_models.py
@@ -60,4 +60,3 @@ class TradeFillData(BaseModel):
     fee_currency: Optional[str] = None # e.g., "USD" or the asset itself
     exchange_order_id: Optional[str] = None
     exchange_trade_id: Optional[str] = None # Often exchanges have a separate trade/fill ID
-```

--- a/python-ai-services/services/agent_management_service.py
+++ b/python-ai-services/services/agent_management_service.py
@@ -367,4 +367,3 @@ class AgentManagementService:
         finally:
             db.close()
 
-```

--- a/python-ai-services/services/agent_orchestrator_service.py
+++ b/python-ai-services/services/agent_orchestrator_service.py
@@ -368,4 +368,3 @@ class AgentOrchestratorService:
                 logger.info(f"Successfully completed agent cycle for {agent.agent_id} ({agent.name}).")
         logger.info("Finished run_all_active_agents_once cycle.")
 
-```

--- a/python-ai-services/services/alert_configuration_service.py
+++ b/python-ai-services/services/alert_configuration_service.py
@@ -96,4 +96,3 @@ class AlertConfigurationService:
         logger.warning(f"Alert config {alert_id} not found for deletion.")
         return False
 
-```

--- a/python-ai-services/services/alert_monitoring_service.py
+++ b/python-ai-services/services/alert_monitoring_service.py
@@ -190,4 +190,3 @@ class AlertMonitoringService:
 
         return triggered_notifications
 
-```

--- a/python-ai-services/services/darvas_box_service.py
+++ b/python-ai-services/services/darvas_box_service.py
@@ -138,4 +138,3 @@ class DarvasBoxTechnicalService:
                 notes=f"No Darvas Box breakout for {symbol}.",
                 tags=["darvas_box", "no_signal"]
             )
-```

--- a/python-ai-services/services/event_bus_service.py
+++ b/python-ai-services/services/event_bus_service.py
@@ -88,4 +88,3 @@ class EventBusService:
 
         logger.debug(f"Finished publishing event ID {event.event_id} to {len(tasks)} subscriber(s).")
 
-```

--- a/python-ai-services/services/heikin_ashi_service.py
+++ b/python-ai-services/services/heikin_ashi_service.py
@@ -201,4 +201,3 @@ class HeikinAshiTechnicalService:
             logger.success(f"HeikinAshiSvc ({self.agent_config.agent_id}): Published {action.upper()} signal for {symbol} at {current_actual_price:.4f}. SL: {sl_price_rounded if sl_price_rounded else 'N/A'}")
         else:
             logger.info(f"HeikinAshiSvc ({self.agent_config.agent_id}): No signal generated for {symbol}.")
-```

--- a/python-ai-services/services/hyperliquid_execution_service.py
+++ b/python-ai-services/services/hyperliquid_execution_service.py
@@ -639,4 +639,3 @@ class HyperliquidExecutionService:
         except Exception as e:
             logger.error(f"HLES: Error fetching fills for order OID {oid}: {e}", exc_info=True)
             raise HyperliquidExecutionServiceError(f"Failed to fetch fills for order {oid}: {e}")
-```

--- a/python-ai-services/services/learning_data_logger_service.py
+++ b/python-ai-services/services/learning_data_logger_service.py
@@ -54,4 +54,3 @@ class LearningDataLoggerService:
         except Exception as e_generic: # Catch any other unexpected errors during file write
             logger.error(f"Unexpected error writing to learning log {self.log_file_path}: {e_generic}", exc_info=True)
             raise
-```

--- a/python-ai-services/services/market_condition_classifier_service.py
+++ b/python-ai-services/services/market_condition_classifier_service.py
@@ -213,4 +213,3 @@ class MarketConditionClassifierService:
         )
         await self.event_bus.publish(event)
 
-```

--- a/python-ai-services/services/news_analysis_service.py
+++ b/python-ai-services/services/news_analysis_service.py
@@ -186,4 +186,3 @@ class NewsAnalysisService:
                 await self.event_bus.publish(event)
                 logger.debug(f"NewsSvc ({self.agent_config.agent_id}): Published NewsArticleEvent for: {headline[:50]}...")
         logger.info(f"NewsSvc ({self.agent_config.agent_id}): Finished feed fetch and analysis cycle.")
-```

--- a/python-ai-services/services/order_history_service.py
+++ b/python-ai-services/services/order_history_service.py
@@ -282,4 +282,3 @@ class OrderHistoryService:
         finally:
             db.close()
 
-```

--- a/python-ai-services/services/performance_calculation_service.py
+++ b/python-ai-services/services/performance_calculation_service.py
@@ -233,4 +233,3 @@ class PerformanceCalculationService:
 
         return metrics
 
-```

--- a/python-ai-services/services/portfolio_optimizer_service.py
+++ b/python-ai-services/services/portfolio_optimizer_service.py
@@ -225,4 +225,3 @@ class PortfolioOptimizerService:
                     notes=f"No effective changes to apply for rule '{rule.rule_name}' to agent {agent_to_update.agent_id}."
                 )
 
-```

--- a/python-ai-services/services/portfolio_snapshot_service.py
+++ b/python-ai-services/services/portfolio_snapshot_service.py
@@ -104,4 +104,3 @@ class PortfolioSnapshotService:
             raise PortfolioSnapshotServiceError(f"Failed to fetch historical snapshots: {e}")
         finally:
             db.close()
-```

--- a/python-ai-services/services/regulatory_compliance_service.py
+++ b/python-ai-services/services/regulatory_compliance_service.py
@@ -91,4 +91,3 @@ class RegulatoryComplianceService:
             for v_rule in result.violated_rules:
                 logger.warning(f"  - Violated Rule ID: {v_rule.rule_id}, Description: {v_rule.description}, Reason: {v_rule.reason}")
         return result
-```

--- a/python-ai-services/services/renko_technical_service.py
+++ b/python-ai-services/services/renko_technical_service.py
@@ -227,4 +227,3 @@ class RenkoTechnicalService:
             await self._log_learning_event("SignalEvaluation", data=log_data_snapshot, outcome={"signal_generated": False}, notes="No Renko signal based on consecutive bricks.", tags=["renko", "no_signal"])
             logger.info(f"RenkoSvc ({self.agent_config.agent_id}): No signal for {symbol} based on last {self.params.signal_confirmation_bricks} bricks.")
 
-```

--- a/python-ai-services/services/risk_manager_service.py
+++ b/python-ai-services/services/risk_manager_service.py
@@ -162,4 +162,3 @@ class RiskManagerService:
         logger.info(f"RiskManager: Trade signal for {trade_signal.symbol} from agent {agent_id_of_proposer} approved by all active checks.")
         return RiskAssessmentResponseData(signal_approved=True)
 
-```

--- a/python-ai-services/services/simulation_service.py
+++ b/python-ai-services/services/simulation_service.py
@@ -229,4 +229,3 @@ class SimulationService:
             list_of_simulated_trades=simulated_trades,
             equity_curve=equity_curve
         )
-```

--- a/python-ai-services/services/trade_history_service.py
+++ b/python-ai-services/services/trade_history_service.py
@@ -203,4 +203,3 @@ class TradeHistoryService:
         logger.info(f"Generated {len(processed_trades)} processed (closed) trades for agent {agent_id} from DB data.")
         return processed_trades[offset : offset + limit]
 
-```

--- a/python-ai-services/services/trading_data_service.py
+++ b/python-ai-services/services/trading_data_service.py
@@ -202,4 +202,3 @@ class TradingDataService:
             logger.error(f"Error fetching order history for agent {agent_id}: {e}", exc_info=True)
             return []
 
-```

--- a/python-ai-services/services/websocket_relay_service.py
+++ b/python-ai-services/services/websocket_relay_service.py
@@ -98,4 +98,3 @@ class WebSocketRelayService:
             payload=event.payload # event.payload is already dict of PortfolioSnapshotOutput
         )
         await self.connection_manager.send_to_client(agent_id, ws_envelope)
-```

--- a/python-ai-services/services/williams_alligator_service.py
+++ b/python-ai-services/services/williams_alligator_service.py
@@ -193,4 +193,3 @@ class WilliamsAlligatorTechnicalService:
                     tags=["williams_alligator", "no_signal"]
                 )
 
-```

--- a/python-ai-services/tests/api/test_live_trading_apis.py
+++ b/python-ai-services/tests/api/test_live_trading_apis.py
@@ -186,4 +186,3 @@ def test_get_order_status_other_service_error(client: TestClient, mock_auth_user
     assert response.json()["detail"] == "HL API timeout"
     app.dependency_overrides.clear()
 
-```

--- a/python-ai-services/tests/api/test_phase4_apis.py
+++ b/python-ai-services/tests/api/test_phase4_apis.py
@@ -906,4 +906,3 @@ async def test_get_strategy_chart_data_redis_get_error(
         delattr(app.state, 'redis_cache_client')
 
 # TODO: Add tests for Redis SET error and JSONDecodeError for visualization endpoint cache.
-```

--- a/python-ai-services/tests/api/v1/test_agent_management_routes.py
+++ b/python-ai-services/tests/api/v1/test_agent_management_routes.py
@@ -242,4 +242,3 @@ def test_get_agent_status_not_found():
     assert response.status_code == 404
     assert "not found or no status available" in response.json()["detail"]
 
-```

--- a/python-ai-services/tests/api/v1/test_alert_routes.py
+++ b/python-ai-services/tests/api/v1/test_alert_routes.py
@@ -214,4 +214,3 @@ def test_delete_alert_config_not_found_or_wrong_agent():
     assert response.status_code == 404
     mock_service_alert_config.delete_alert_config.assert_not_called()
 
-```

--- a/python-ai-services/tests/api/v1/test_dashboard_data_routes.py
+++ b/python-ai-services/tests/api/v1/test_dashboard_data_routes.py
@@ -229,4 +229,3 @@ def test_get_agent_equity_curve_invalid_limit_param():
     assert response_high.status_code == 422
 
     mock_service_pss.get_historical_snapshots.assert_not_called() # Should not be called if params fail validation
-```

--- a/python-ai-services/tests/api/v1/test_monitoring_routes.py
+++ b/python-ai-services/tests/api/v1/test_monitoring_routes.py
@@ -183,4 +183,3 @@ def test_get_system_health_summary_success(mock_get_deep_health: AsyncMock, clie
 
     mock_get_deep_health.assert_called_once()
 
-```

--- a/python-ai-services/tests/api/v1/test_performance_routes.py
+++ b/python-ai-services/tests/api/v1/test_performance_routes.py
@@ -110,4 +110,3 @@ def test_get_agent_performance_metrics_unexpected_error():
     assert "Unexpected internal error" in response.json()["detail"]
     mock_service_perf.calculate_performance_metrics.assert_called_once_with(agent_id)
 
-```

--- a/python-ai-services/tests/api/v1/test_simulation_routes.py
+++ b/python-ai-services/tests/api/v1/test_simulation_routes.py
@@ -170,4 +170,3 @@ def test_run_backtest_endpoint_unexpected_error(
 
 # Need to import datetime and timezone for create_mock_backtest_result
 from datetime import datetime, timezone
-```

--- a/python-ai-services/tests/auth/test_dependencies.py
+++ b/python-ai-services/tests/auth/test_dependencies.py
@@ -150,4 +150,3 @@ async def test_get_current_active_user_pydantic_validation_error(mock_jwt_decode
         await get_current_active_user(token=mock_auth_creds)
     assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert "Invalid user data structure in token" in exc_info.value.detail
-```

--- a/python-ai-services/tests/core/test_scheduler_setup.py
+++ b/python-ai-services/tests/core/test_scheduler_setup.py
@@ -187,4 +187,3 @@ def test_shutdown_scheduler_when_stopped(mock_scheduler: MagicMock):
 
     scheduler_setup.shutdown_scheduler()
     mock_scheduler.shutdown.assert_not_called() # Should not call shutdown if not running
-```

--- a/python-ai-services/tests/core/test_websocket_manager.py
+++ b/python-ai-services/tests/core/test_websocket_manager.py
@@ -146,4 +146,3 @@ def test_connection_manager_singleton_instance_exists():
     except ImportError:
         pytest.fail("Could not import global connection_manager instance from core.websocket_manager")
 
-```

--- a/python-ai-services/tests/services/test_agent_management_service.py
+++ b/python-ai-services/tests/services/test_agent_management_service.py
@@ -319,4 +319,3 @@ async def test_update_agent_heartbeat_db(service: AgentManagementService): # Alr
     assert updated_status.last_heartbeat > initial_heartbeat
     assert updated_status.status == "running"
 
-```

--- a/python-ai-services/tests/services/test_agent_orchestrator_service.py
+++ b/python-ai-services/tests/services/test_agent_orchestrator_service.py
@@ -512,4 +512,3 @@ async def test_run_all_active_agents_one_cycle_fails(orchestrator_service: Agent
     assert orchestrator_service.run_single_agent_cycle.call_count == 2
 
 from typing import Optional, List, Dict, Any # Ensure all type hints are imported
-```

--- a/python-ai-services/tests/services/test_agent_persistence_service.py
+++ b/python-ai-services/tests/services/test_agent_persistence_service.py
@@ -533,4 +533,3 @@ class TestAgentTaskPersistence:
         assert total == 5  # Total count was successfully retrieved
         assert "Supabase API error during data query" in caplog.text
         assert service.supabase_client.execute.call_count == 2 # Both count and data queries executed
-```

--- a/python-ai-services/tests/services/test_alert_configuration_service.py
+++ b/python-ai-services/tests/services/test_alert_configuration_service.py
@@ -151,4 +151,3 @@ async def test_delete_alert_config(service: AlertConfigurationService):
 
 # Need asyncio for sleep
 import asyncio
-```

--- a/python-ai-services/tests/services/test_alert_monitoring_service.py
+++ b/python-ai-services/tests/services/test_alert_monitoring_service.py
@@ -282,4 +282,3 @@ async def test_send_notifications_event_bus_unavailable(alert_monitoring_service
 
 # Need List, Optional from typing for helpers
 from typing import List, Optional, Any # Added Any
-```

--- a/python-ai-services/tests/services/test_darvas_box_service.py
+++ b/python-ai-services/tests/services/test_darvas_box_service.py
@@ -173,4 +173,3 @@ async def test_analyze_box_range_check_disabled(mock_event_bus, mock_market_data
 # Need Optional, List, Dict, Any for helpers and typing
 from typing import Optional, List, Dict, Any
 from datetime import datetime, timezone, timedelta # For helper
-```

--- a/python-ai-services/tests/services/test_dex_execution_service.py
+++ b/python-ai-services/tests/services/test_dex_execution_service.py
@@ -406,4 +406,3 @@ async def test_place_swap_order_parses_amount_out_from_logs(dex_service):
     assert result["amount_out_wei_actual"] == actual_amount_out_wei
     assert result["amount_out_wei_minimum_requested"] == MIN_AMOUNT_OUT_WEI
 
-```

--- a/python-ai-services/tests/services/test_event_bus_service.py
+++ b/python-ai-services/tests/services/test_event_bus_service.py
@@ -169,4 +169,3 @@ async def test_publish_with_non_async_subscriber_is_skipped(event_bus: EventBusS
         args, _ = mock_log_error.call_args
         assert "is not an async function as expected. Skipping." in args[0]
 
-```

--- a/python-ai-services/tests/services/test_heikin_ashi_service.py
+++ b/python-ai-services/tests/services/test_heikin_ashi_service.py
@@ -190,4 +190,3 @@ async def test_analyze_no_signal_choppy_market(ha_service: HeikinAshiTechnicalSe
 # Add more tests:
 # - ATR calculation for SL returns None (SL should be None)
 # - Kline data has NaNs or missing columns (graceful handling)
-```

--- a/python-ai-services/tests/services/test_hyperliquid_execution_service.py
+++ b/python-ai-services/tests/services/test_hyperliquid_execution_service.py
@@ -1029,4 +1029,3 @@ async def test_get_fills_for_order_info_client_not_initialized(mock_hl_init_bypa
     fills = await service.get_fills_for_order("user", 130)
     assert fills == []
     assert "Hyperliquid Info client not initialized. Cannot fetch fills." in caplog.text
-```

--- a/python-ai-services/tests/services/test_market_condition_classifier_service.py
+++ b/python-ai-services/tests/services/test_market_condition_classifier_service.py
@@ -183,4 +183,3 @@ async def test_mcc_ranging_signal_narrow_bbw(
 
 # Need Optional from typing for helper
 from typing import Optional
-```

--- a/python-ai-services/tests/services/test_memory_service.py
+++ b/python-ai-services/tests/services/test_memory_service.py
@@ -475,4 +475,3 @@ async def test_close_letta_client(memory_service_fixture: MemoryService, caplog)
 
     assert memory_service_fixture.letta_client is None
     assert "MEMORY_SERVICE: Letta client connection conceptually closed." in caplog.text
-```

--- a/python-ai-services/tests/services/test_news_analysis_service.py
+++ b/python-ai-services/tests/services/test_news_analysis_service.py
@@ -190,4 +190,3 @@ async def test_fetch_limit_per_feed(mock_feedparser_parse: MagicMock, mock_event
     payload = NewsArticleEventPayload(**mock_event_bus.publish.call_args[0][0].payload)
     assert payload.headline == "Title 1"
 
-```

--- a/python-ai-services/tests/services/test_order_history_service.py
+++ b/python-ai-services/tests/services/test_order_history_service.py
@@ -222,4 +222,3 @@ async def test_db_order_to_pydantic_log_item(order_history_service: OrderHistory
     assert pydantic_item.strategy_name == "TestStrategyOrderLog"
     # Check if timestamp_created is used for 'timestamp' field in OrderLogItem
     assert pydantic_item.timestamp_created == db_order.timestamp_created
-```

--- a/python-ai-services/tests/services/test_performance_calculation_service.py
+++ b/python-ai-services/tests/services/test_performance_calculation_service.py
@@ -189,4 +189,3 @@ async def test_calculate_performance_invalid_pnl_values(
 
 # Need uuid for helper
 import uuid
-```

--- a/python-ai-services/tests/services/test_portfolio_optimizer_service.py
+++ b/python-ai-services/tests/services/test_portfolio_optimizer_service.py
@@ -381,4 +381,3 @@ async def test_on_news_article_event_invalid_payload(
 # Ensure all type hints are imported
 from typing import List, Dict, Any, Optional, Literal
 from datetime import datetime, timezone
-```

--- a/python-ai-services/tests/services/test_portfolio_snapshot_service.py
+++ b/python-ai-services/tests/services/test_portfolio_snapshot_service.py
@@ -158,4 +158,3 @@ async def test_get_historical_snapshots_no_records(snapshot_service: PortfolioSn
 
 # Need to import MagicMock for the mock_event_bus fixture
 from unittest.mock import MagicMock
-```

--- a/python-ai-services/tests/services/test_renko_technical_service.py
+++ b/python-ai-services/tests/services/test_renko_technical_service.py
@@ -252,4 +252,3 @@ async def test_analyze_sell_signal_generated(renko_service: RenkoTechnicalServic
     assert payload.price_target == pytest.approx(98.5)
     # First signal brick is [101,100] down. SL is its open.
     assert payload.stop_loss == pytest.approx(101.0)
-```

--- a/python-ai-services/tests/services/test_risk_manager_service.py
+++ b/python-ai-services/tests/services/test_risk_manager_service.py
@@ -292,4 +292,3 @@ async def test_assess_risk_max_exposure_per_asset_usd_exceeded(
 
 # Need Optional and List for type hints in helper
 from typing import Optional, List
-```

--- a/python-ai-services/tests/services/test_simulation_service.py
+++ b/python-ai-services/tests/services/test_simulation_service.py
@@ -249,4 +249,3 @@ async def test_run_backtest_insufficient_capital_for_buy(simulation_service: Sim
 # TODO: Add tests for sell logic and round trip P&L calculation when implemented more fully
 # TODO: Test for date parsing errors in request
 # TODO: Test for empty klines from market_data_service (should raise error or return empty result)
-```

--- a/python-ai-services/tests/services/test_strategy_config_service.py
+++ b/python-ai-services/tests/services/test_strategy_config_service.py
@@ -265,4 +265,3 @@ async def test_get_all_user_strategies_with_performance_teasers_no_strategies(st
     assert len(teasers) == 0
     strategy_config_service_instance.get_latest_performance_metrics.assert_not_called()
 
-```

--- a/python-ai-services/tests/services/test_strategy_visualization_service.py
+++ b/python-ai-services/tests/services/test_strategy_visualization_service.py
@@ -212,4 +212,3 @@ async def test_get_strategy_visualization_data_no_price_data(
 # - Test case where price_df is empty after fetching. (Covered by "Could not fetch price data" if None, but also for empty DataFrame)
 # - Test indicator extraction logic with more complex scenarios (e.g. multi-value indicators, all NaNs)
 # - Test OHLCVBar creation with missing Volume data.
-```

--- a/python-ai-services/tests/services/test_trade_history_service.py
+++ b/python-ai-services/tests/services/test_trade_history_service.py
@@ -326,4 +326,3 @@ async def test_get_processed_trades_multiple_assets_db(service: TradeHistoryServ
 # Optional: Import for type hinting if not already present
 from typing import Optional
 from unittest.mock import MagicMock, AsyncMock # Ensure these are at the top if used by new fixtures
-```

--- a/python-ai-services/tests/services/test_trading_coordinator.py
+++ b/python-ai-services/tests/services/test_trading_coordinator.py
@@ -683,4 +683,3 @@ async def test_handle_market_condition_event_logs_info(trading_coordinator: Trad
 # Need to import 'call' for assert_has_calls
 from unittest.mock import call
 
-```

--- a/python-ai-services/tests/services/test_trading_data_service.py
+++ b/python-ai-services/tests/services/test_trading_data_service.py
@@ -272,4 +272,3 @@ async def test_get_order_history_mocked(trading_data_service: TradingDataService
         assert isinstance(item, OrderLogItem)
         assert item.agent_id == agent_id
 
-```

--- a/python-ai-services/tests/services/test_watchlist_service.py
+++ b/python-ai-services/tests/services/test_watchlist_service.py
@@ -561,4 +561,3 @@ async def test_get_batch_quotes_for_symbols_empty_list(watchlist_service: Watchl
     # Assert
     assert len(response.results) == 0
 
-```

--- a/python-ai-services/tests/services/test_websocket_relay_service.py
+++ b/python-ai-services/tests/services/test_websocket_relay_service.py
@@ -178,4 +178,3 @@ async def test_event_handler_invalid_payload_type(websocket_relay_service: WebSo
     await websocket_relay_service.on_new_fill_recorded(event_invalid_payload)
     mock_connection_manager.send_to_client.assert_not_called()
     assert "Invalid payload type for NewFillRecordedEvent: <class 'str'>. Expected dict." in caplog.text
-```

--- a/python-ai-services/tests/services/test_williams_alligator_service.py
+++ b/python-ai-services/tests/services/test_williams_alligator_service.py
@@ -239,4 +239,3 @@ async def test_analyze_no_signal(mock_event_bus, mock_market_data_service):
 # Need Optional from typing for helper
 from typing import Optional
 from datetime import datetime, timezone, timedelta # For helper
-```

--- a/python-ai-services/tests/strategies/test_darvas_box.py
+++ b/python-ai-services/tests/strategies/test_darvas_box.py
@@ -271,4 +271,3 @@ def test_run_darvas_box_parameter_sensitivity_min_duration(default_darvas_config
 # - test_run_darvas_box_multiple_boxes_and_signals (requires more complex data setup)
 # - test_run_darvas_box_box_definition_period_timeout
 # - test_run_darvas_box_bottom_violation_after_confirmation (box breaks down, no signal)
-```

--- a/python-ai-services/tests/strategies/test_elliott_wave.py
+++ b/python-ai-services/tests/strategies/test_elliott_wave.py
@@ -200,4 +200,3 @@ def test_run_elliott_wave_config_usage_in_output(custom_elliott_wave_config: Ell
             expected_high = round(last_wave_price * (1 + custom_elliott_wave_config.zigzag_threshold_percent / 100), 2)
             assert target_high == expected_high
 
-```

--- a/python-ai-services/tests/strategies/test_heikin_ashi.py
+++ b/python-ai-services/tests/strategies/test_heikin_ashi.py
@@ -174,4 +174,3 @@ def test_ha_no_signals_insufficient_data(default_ha_config: HeikinAshiConfig):
 # - test_ha_exit_long_on_weak_green_candle
 # - test_ha_hold_in_strong_bullish_trend_after_buy
 # - test_ha_small_wick_threshold_impact
-```

--- a/python-ai-services/tests/strategies/test_renko.py
+++ b/python-ai-services/tests/strategies/test_renko.py
@@ -198,4 +198,3 @@ def test_run_renko_signal_buy_after_two_up_bricks(fixed_renko_config_default: Re
     assert buy_signals[0]["brick_type"] == "up"
     assert "Two consecutive 'up' bricks" in buy_signals[0]["reason"]
 
-```

--- a/python-ai-services/tests/strategies/test_williams_alligator.py
+++ b/python-ai-services/tests/strategies/test_williams_alligator.py
@@ -227,4 +227,3 @@ def test_alligator_no_signals_insufficient_data(default_alligator_config: Willia
 # - test_alligator_price_source_hlc3 (verifying SMMA calculation uses hlc3)
 # - test_alligator_handles_initial_nans_in_indicators_for_signals (ensure no signals if lines are NaN)
 
-```

--- a/python-ai-services/tests/test_integration_flows.py
+++ b/python-ai-services/tests/test_integration_flows.py
@@ -259,4 +259,3 @@ async def test_flow_market_data_triggers_analysis(agent_state_manager_fixture: m
         f"{market_data_payload_from_a2a['symbol']}_insight",
         "ETH showing consolidation around 3k, RSI neutral." # from llm_insight
     )
-```

--- a/python-ai-services/tests/test_services.py
+++ b/python-ai-services/tests/test_services.py
@@ -862,4 +862,3 @@ async def test_memory_service_initialization_failure_propagates():
         with pytest.raises(MemoryInitializationError, match="Failed to initialize MemGPT: MemGPT Global Init Failed"):
             # Attempt to instantiate MemoryService, which should trigger the mocked MemGPT error
             MemoryService(user_id=uuid.uuid4(), agent_id_context=uuid.uuid4())
-```

--- a/python-ai-services/tests/test_trading_crew.py
+++ b/python-ai-services/tests/test_trading_crew.py
@@ -437,4 +437,3 @@ async def test_run_analysis_task_creation_fails(trading_crew_service: TradingCre
     trading_crew_service._get_llm_instance.assert_not_called()
     mock_persistence_service.update_agent_task_status.assert_not_called()
     mock_persistence_service.update_agent_task_result.assert_not_called()
-```

--- a/python-ai-services/tests/tools/test_market_data_tools.py
+++ b/python-ai-services/tests/tools/test_market_data_tools.py
@@ -171,4 +171,3 @@ async def test_fetch_market_data_tool_default_days_with_service_call():
     assert data["historical_days"] == 30 # Field name updated
     assert data["limit_calculated"] == expected_limit
     assert data["data_points_returned"] == expected_limit
-```

--- a/python-ai-services/tests/tools/test_memory_tools.py
+++ b/python-ai-services/tests/tools/test_memory_tools.py
@@ -192,4 +192,3 @@ def test_recall_memories_tool_args_schema():
     else:
         pytest.fail("Tool schema attribute not found for recall_memories_tool.")
 
-```

--- a/python-ai-services/tests/tools/test_risk_assessment_tools.py
+++ b/python-ai-services/tests/tools/test_risk_assessment_tools.py
@@ -268,4 +268,3 @@ def test_assess_trade_risk_tool_invalid_input_via_pydantic_schema():
     assert "Failed to assess risk due to input validation errors" in data["assessment_summary"]
     assert any("Input tag 'MAYBEBUY' found using 'str_to_instance'" in detail_msg for detail_msg in data["warnings"])
 
-```

--- a/python-ai-services/tests/tools/test_strategy_application_tools.py
+++ b/python-ai-services/tests/tools/test_strategy_application_tools.py
@@ -534,4 +534,3 @@ def test_all_tools_args_schema_linkage():
             # or if the tool is a native CrewAI tool that doesn't use 'args_schema' in the same way.
             pytest.fail(f"Tool schema attribute not found or not matching for {tool_func.__name__} using common patterns. Tool object: {tool_func}")
 
-```

--- a/python-ai-services/tests/tools/test_technical_analysis_tools.py
+++ b/python-ai-services/tests/tools/test_technical_analysis_tools.py
@@ -146,4 +146,3 @@ def test_run_technical_analysis_tool_args_schema():
     else:
         pytest.skip("Tool schema attribute not found, decorator might be a simple stub or crewai internal changed.")
 
-```

--- a/python-ai-services/tools/market_data_tools.py
+++ b/python-ai-services/tools/market_data_tools.py
@@ -277,4 +277,3 @@ async def main_async_example():
 if __name__ == '__main__':
     import asyncio
     asyncio.run(main_async_example())
-```

--- a/python-ai-services/tools/memory_tools.py
+++ b/python-ai-services/tools/memory_tools.py
@@ -198,4 +198,3 @@ if __name__ == '__main__':
 
     asyncio.run(demo_tools())
 
-```

--- a/python-ai-services/tools/risk_assessment_tools.py
+++ b/python-ai-services/tools/risk_assessment_tools.py
@@ -319,4 +319,3 @@ if __name__ == '__main__':
     logger.info(f"\n--- Example 5: Existing Position ({args5_dict['symbol']}) ---")
     result5_json = assess_trade_risk_tool(**args5_dict)
     logger.info(f"Risk Assessment Tool Output 5:\n{json.dumps(json.loads(result5_json), indent=2)}")
-```

--- a/python-ai-services/tools/strategy_application_tools.py
+++ b/python-ai-services/tools/strategy_application_tools.py
@@ -723,4 +723,3 @@ def apply_elliott_wave_tool(processed_market_data_json: str, elliott_wave_config
     error_output_ew_cfg = apply_elliott_wave_tool(**tool_args_invalid_ew_cfg.dict())
     logger.info(f"Apply Elliott Wave Strategy Tool (Stub) Output (Invalid Config):\n{json.dumps(json.loads(error_output_ew_cfg), indent=2, default=str)}")
 
-```

--- a/python-ai-services/tools/technical_analysis_tools.py
+++ b/python-ai-services/tools/technical_analysis_tools.py
@@ -184,4 +184,3 @@ if __name__ == '__main__':
     ta_empty_data_output = run_technical_analysis_tool(market_data_json=empty_data_json)
     logger.info(f"Technical Analysis Tool Output (Empty data list input):\n{json.dumps(json.loads(ta_empty_data_output), indent=2)}")
 
-```

--- a/tests/api/v1/test_simulation_routes.py
+++ b/tests/api/v1/test_simulation_routes.py
@@ -178,4 +178,3 @@ def test_run_backtest_endpoint_invalid_request_payload(#client: TestClient
     }
     response = client.post("/api/v1/simulations/backtest", json=invalid_payload)
     assert response.status_code == 422 # FastAPI's unprocessable entity for Pydantic validation errors
-```

--- a/tests/services/test_darvas_box_service.py
+++ b/tests/services/test_darvas_box_service.py
@@ -165,4 +165,3 @@ async def test_analyze_darvas_insufficient_data(
     for call_arg in mock_learning_logger_service.log_entry.call_args_list:
         entry_arg: LearningLogEntry = call_arg[0][0]
         assert entry_arg.event_type not in ["SignalGenerated", "SignalEvaluation"]
-```

--- a/tests/services/test_learning_data_logger_service.py
+++ b/tests/services/test_learning_data_logger_service.py
@@ -152,4 +152,3 @@ async def test_log_entry_handles_serialization_failure(learning_logger_service: 
     # The exact error message for serialization failure can vary.
     # Example check:
     assert "is not JSON serializable" in caplog.text or "PydanticSerializationError" in caplog.text
-```

--- a/tests/services/test_market_condition_classifier_service.py
+++ b/tests/services/test_market_condition_classifier_service.py
@@ -127,4 +127,3 @@ async def test_analyze_mcc_insufficient_data(
     # No learning log expected if it exits early due to insufficient data,
     # unless a specific "ProcessingError" or "InsufficientData" log is added.
     mock_learning_logger_service.log_entry.assert_not_called()
-```

--- a/tests/services/test_news_analysis_service.py
+++ b/tests/services/test_news_analysis_service.py
@@ -142,4 +142,3 @@ async def test_fetch_and_analyze_feed_error(
 
 # Need uuid for mock_entry.link default value if not provided in test data
 import uuid
-```

--- a/tests/services/test_performance_calculation_service.py
+++ b/tests/services/test_performance_calculation_service.py
@@ -196,4 +196,3 @@ async def test_calculate_cagr_negative_total_return(performance_service: Perform
     metrics = await performance_service.calculate_performance_metrics("test_agent_neg_return")
     assert metrics.compounding_annual_return_percentage is not None
     assert metrics.compounding_annual_return_percentage < 0
-```

--- a/tests/services/test_portfolio_optimizer_service.py
+++ b/tests/services/test_portfolio_optimizer_service.py
@@ -323,4 +323,3 @@ async def test_on_news_article_event_invalid_payload(
     # Check that no "OptimizerRuleMatched" learning log was made
     assert not any(c[0][0].event_type == "OptimizerRuleMatched" for c in mock_learning_logger_service.log_entry.call_args_list)
 
-```

--- a/tests/services/test_regulatory_compliance_service.py
+++ b/tests/services/test_regulatory_compliance_service.py
@@ -220,4 +220,3 @@ async def test_max_daily_trades_missing_symbol_in_params(compliance_service: Reg
     result = await service.check_action_compliance(request)
     assert result.is_compliant is True
     assert "is missing 'symbol' in parameters. Skipping rule." in caplog.text
-```

--- a/tests/services/test_simulation_service.py
+++ b/tests/services/test_simulation_service.py
@@ -250,4 +250,3 @@ async def test_run_backtest_no_signals_no_trades(simulation_service: SimulationS
 # - Test using agent_id_to_simulate (mocking AMS.get_agent)
 # - Test equity curve values at various points
 # - Test calculation of other BacktestResult metrics (win_rate, etc.) once PnL logic is robust
-```

--- a/tests/services/test_trading_coordinator.py
+++ b/tests/services/test_trading_coordinator.py
@@ -336,4 +336,3 @@ def test_trading_coordinator_init_with_all_services(
     )
     assert tc.compliance_service == mock_compliance_service
     assert tc.learning_logger_service == mock_learning_logger_service # Added
-```

--- a/tests/services/test_williams_alligator_service.py
+++ b/tests/services/test_williams_alligator_service.py
@@ -176,4 +176,3 @@ async def test_analyze_alligator_insufficient_data(
     # No learning log for this specific early exit, as per current service code.
     # If a "ProcessingError" or "InsufficientData" log were added, this test would check for it.
     mock_learning_logger_service.log_entry.assert_not_called()
-```


### PR DESCRIPTION
## Summary
- remove leftover ``` lines from Python modules
- ensure all Python files compile

## Testing
- `python3 -m py_compile` on all Python files

------
https://chatgpt.com/codex/tasks/task_e_684320c7460c832b8d6bcf6783d9b128