### PR TITLE
Initialize agent statuses on startup

### DIFF
--- a/python-ai-services/main.py
+++ b/python-ai-services/main.py
@@ -33,6 +33,7 @@ from services.agent_persistence_service import AgentPersistenceService
 from services.agent_state_manager import AgentStateManager
 from services.memory_service import MemoryService, LETTA_CLIENT_AVAILABLE
 from crews.trading_crew_service import TradingCrewService, TradingCrewRequest
+from api.v1.agent_management_routes import get_agent_management_service
 
 # Added for monitoring API
 from fastapi import Query # Query for pagination params
@@ -335,6 +336,15 @@ async def lifespan(app: FastAPI):
         logger.error(f"Failed to initialize MemoryService: {e}. Memory capabilities may be unavailable.")
         if "memory_service" not in services: # Ensure it's None if init fails badly
             services["memory_service"] = None
+
+    # Load agent runtime statuses at startup
+    try:
+        agent_management_service = get_agent_management_service()
+        services["agent_management_service"] = agent_management_service
+        logger.info("Loading agent statuses from database...")
+        await agent_management_service.load_all_agent_statuses_from_db()
+    except Exception as e:
+        logger.error(f"Failed loading agent statuses on startup: {e}", exc_info=True)
 
 
     logger.info("✅ All services initialized (or initialization attempted).")

--- a/python-ai-services/services/agent_management_service.py
+++ b/python-ai-services/services/agent_management_service.py
@@ -41,6 +41,13 @@ class AgentManagementService:
         finally:
             db.close()
 
+    async def load_all_agent_statuses_from_db(self) -> None:
+        """Public wrapper to initialize in-memory agent statuses from the database."""
+        await self._load_existing_statuses_from_db()
+        logger.info(
+            f"Loaded agent runtime statuses for {len(self._agent_statuses)} agents from DB."
+        )
+
     def _db_to_pydantic(self, db_agent: AgentConfigDB) -> AgentConfigOutput:
         try:
             strategy_data = json.loads(db_agent.strategy_config_json or "{}")


### PR DESCRIPTION
## Summary
- expose `load_all_agent_statuses_from_db` on AgentManagementService
- load agent statuses during FastAPI startup
- add startup logging around status loading

## Testing
- `pytest -k load_all_agent_statuses_from_db -q` *(fails: SyntaxError & missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684320d32150832ba347ac9b6eb585bd